### PR TITLE
Add payroll metrics and CSV export to student directory

### DIFF
--- a/src/components/StudentDirectory.jsx
+++ b/src/components/StudentDirectory.jsx
@@ -1,7 +1,97 @@
 import React, { useState, useMemo } from 'react';
-import { Edit, Save, X, GraduationCap, Mail, Phone, PhoneOff, Clock, Search, ArrowUpDown, Plus, RotateCcw, History, Trash2, Filter } from 'lucide-react';
+import { Edit, Save, X, GraduationCap, Mail, Phone, PhoneOff, Clock, Search, ArrowUpDown, Plus, RotateCcw, History, Trash2, Filter, Download, BarChart3, DollarSign } from 'lucide-react';
 import MultiSelectDropdown from './MultiSelectDropdown';
 import FacultyContactCard from './FacultyContactCard';
+
+const parseHourlyRate = (value) => {
+  if (value === null || value === undefined) return 0;
+  if (typeof value === 'number') return isFinite(value) ? value : 0;
+  const cleaned = String(value).replace(/[^0-9.-]/g, '');
+  const parsed = parseFloat(cleaned);
+  return isFinite(parsed) ? parsed : 0;
+};
+
+const calculateEntryMinutes = (entry) => {
+  if (!entry || !entry.start || !entry.end) return 0;
+  const parseTime = (timeStr) => {
+    if (typeof timeStr !== 'string') return null;
+    const [hourStr, minuteStr = '0'] = timeStr.split(':');
+    const hour = parseInt(hourStr, 10);
+    const minute = parseInt(minuteStr, 10);
+    if (Number.isNaN(hour) || Number.isNaN(minute)) return null;
+    return hour * 60 + minute;
+  };
+
+  const startMinutes = parseTime(entry.start);
+  const endMinutes = parseTime(entry.end);
+  if (startMinutes === null || endMinutes === null) return 0;
+  const diff = endMinutes - startMinutes;
+  return diff > 0 ? diff : 0;
+};
+
+const calculateWeeklyHoursFromSchedule = (schedule) => {
+  if (!Array.isArray(schedule) || schedule.length === 0) return 0;
+  const totalMinutes = schedule.reduce((sum, entry) => sum + calculateEntryMinutes(entry), 0);
+  return totalMinutes / 60;
+};
+
+const getStudentAssignments = (student) => {
+  if (!student) return [];
+
+  const fallbackSchedule = Array.isArray(student.weeklySchedule) ? student.weeklySchedule : [];
+  const fallbackBuildings = Array.isArray(student.primaryBuildings)
+    ? student.primaryBuildings.filter(Boolean)
+    : (student.primaryBuilding ? [student.primaryBuilding] : []);
+
+  const jobs = Array.isArray(student.jobs) && student.jobs.length > 0
+    ? student.jobs
+    : [{
+        jobTitle: student.jobTitle || '',
+        supervisor: student.supervisor || '',
+        hourlyRate: student.hourlyRate,
+        location: fallbackBuildings,
+        weeklySchedule: fallbackSchedule
+      }];
+
+  return jobs.map((job, index) => {
+    const schedule = Array.isArray(job.weeklySchedule) && job.weeklySchedule.length > 0
+      ? job.weeklySchedule
+      : fallbackSchedule;
+
+    const buildings = Array.isArray(job.location)
+      ? job.location.filter(Boolean)
+      : (job.location ? [job.location] : fallbackBuildings);
+
+    const hourlyRateNumber = parseHourlyRate(job.hourlyRate ?? student.hourlyRate);
+    const weeklyHours = calculateWeeklyHoursFromSchedule(schedule);
+    const weeklyPay = hourlyRateNumber * weeklyHours;
+
+    return {
+      ...job,
+      jobTitle: job.jobTitle || student.jobTitle || `Assignment ${index + 1}`,
+      supervisor: job.supervisor || student.supervisor || '',
+      schedule,
+      buildings,
+      hourlyRateNumber,
+      hourlyRateDisplay: hourlyRateNumber ? `$${hourlyRateNumber.toFixed(2)}` : (job.hourlyRate || student.hourlyRate || ''),
+      weeklyHours,
+      weeklyPay,
+    };
+  });
+};
+
+const getStudentTotalWeeklyHours = (student) => {
+  return getStudentAssignments(student).reduce((sum, assignment) => sum + assignment.weeklyHours, 0);
+};
+
+const toComparableValue = (value) => {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') return value.toLowerCase();
+  if (Array.isArray(value)) return value.join(' ').toLowerCase();
+  if (typeof value === 'boolean') return value ? '1' : '0';
+  return String(value).toLowerCase();
+};
 
 const formatPhoneNumber = (phoneStr) => {
     if (!phoneStr) return '-';
@@ -62,6 +152,7 @@ const StudentDirectory = ({ studentData, rawScheduleData, onStudentUpdate, onStu
     activeOnly: true,
     includeEnded: false
   });
+  const [metricsFilters, setMetricsFilters] = useState({ jobTitles: [], buildings: [] });
 
   // Extract departments and supervisors for filtering
   const availableJobTitles = useMemo(() => {
@@ -110,7 +201,7 @@ const StudentDirectory = ({ studentData, rawScheduleData, onStudentUpdate, onStu
   const filteredAndSortedData = useMemo(() => {
     let filtered = studentData.filter(student => {
       if (!student) return false;
-      
+
       // Text filter
       if (filterText) {
         const searchText = filterText.toLowerCase();
@@ -171,7 +262,17 @@ const StudentDirectory = ({ studentData, rawScheduleData, onStudentUpdate, onStu
 
     // Sort data
     return filtered.sort((a, b) => {
-      let aValue, bValue;
+      if (sortConfig.key === 'weeklyHours') {
+        const aHours = getStudentTotalWeeklyHours(a);
+        const bHours = getStudentTotalWeeklyHours(b);
+        const diff = aHours - bHours;
+        if (diff !== 0) {
+          return sortConfig.direction === 'ascending' ? diff : -diff;
+        }
+      }
+
+      let aValue;
+      let bValue;
 
       switch (sortConfig.key) {
         case 'name':
@@ -196,17 +297,117 @@ const StudentDirectory = ({ studentData, rawScheduleData, onStudentUpdate, onStu
           bValue = b.supervisor || '';
           break;
         default:
-          aValue = a[sortConfig.key] || '';
-          bValue = b[sortConfig.key] || '';
+          aValue = a[sortConfig.key];
+          bValue = b[sortConfig.key];
       }
 
-      if (sortConfig.direction === 'ascending') {
-        return aValue.localeCompare(bValue);
-      } else {
-        return bValue.localeCompare(aValue);
+      const normalizedA = toComparableValue(aValue);
+      const normalizedB = toComparableValue(bValue);
+
+      if (typeof normalizedA === 'number' && typeof normalizedB === 'number') {
+        const diff = normalizedA - normalizedB;
+        if (diff === 0) return 0;
+        return sortConfig.direction === 'ascending' ? diff : -diff;
       }
+
+      const comparison = normalizedA.toString().localeCompare(normalizedB.toString());
+      return sortConfig.direction === 'ascending' ? comparison : -comparison;
     });
   }, [studentData, filterText, sortConfig, nameSort, filters]);
+
+  const filteredAssignments = useMemo(() => {
+    return filteredAndSortedData.flatMap(student =>
+      getStudentAssignments(student).map(assignment => ({
+        ...assignment,
+        student,
+      }))
+    );
+  }, [filteredAndSortedData]);
+
+  const metricsAssignments = useMemo(() => {
+    return filteredAssignments.filter(assignment => {
+      if ((metricsFilters.jobTitles || []).length > 0 && assignment.jobTitle) {
+        if (!metricsFilters.jobTitles.includes(assignment.jobTitle)) {
+          return false;
+        }
+      } else if ((metricsFilters.jobTitles || []).length > 0 && !assignment.jobTitle) {
+        return false;
+      }
+
+      if ((metricsFilters.buildings || []).length > 0) {
+        const assignmentBuildings = (assignment.buildings || []).length > 0
+          ? assignment.buildings
+          : (assignment.student?.primaryBuildings || assignment.student?.primaryBuilding
+              ? Array.isArray(assignment.student?.primaryBuildings)
+                ? assignment.student.primaryBuildings
+                : [assignment.student.primaryBuilding]
+              : []);
+
+        if (!assignmentBuildings.some(b => metricsFilters.buildings.includes(b))) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }, [filteredAssignments, metricsFilters]);
+
+  const metricsTotals = useMemo(() => {
+    const totalHours = metricsAssignments.reduce((sum, assignment) => sum + assignment.weeklyHours, 0);
+    const totalPay = metricsAssignments.reduce((sum, assignment) => sum + assignment.weeklyPay, 0);
+    const studentCount = new Set(metricsAssignments.map(a => a.student?.id || a.student?.email || a.student?.name)).size;
+    const avgRate = totalHours > 0 ? totalPay / totalHours : 0;
+    return { totalHours, totalPay, studentCount, avgRate };
+  }, [metricsAssignments]);
+
+  const jobTitleBreakdown = useMemo(() => {
+    const map = new Map();
+    metricsAssignments.forEach(assignment => {
+      const key = assignment.jobTitle || 'Unassigned';
+      const existing = map.get(key) || { hours: 0, pay: 0 };
+      existing.hours += assignment.weeklyHours;
+      existing.pay += assignment.weeklyPay;
+      map.set(key, existing);
+    });
+    return Array.from(map.entries())
+      .map(([label, data]) => ({ label, ...data }))
+      .sort((a, b) => b.hours - a.hours);
+  }, [metricsAssignments]);
+
+  const buildingBreakdown = useMemo(() => {
+    const map = new Map();
+    metricsAssignments.forEach(assignment => {
+      const buildings = (assignment.buildings && assignment.buildings.length > 0)
+        ? assignment.buildings
+        : (assignment.student?.primaryBuildings && assignment.student.primaryBuildings.length > 0
+            ? assignment.student.primaryBuildings
+            : assignment.student?.primaryBuilding
+              ? [assignment.student.primaryBuilding]
+              : ['Unassigned']);
+
+      buildings.forEach(building => {
+        const key = building || 'Unassigned';
+        const existing = map.get(key) || { hours: 0, pay: 0 };
+        existing.hours += assignment.weeklyHours;
+        existing.pay += assignment.weeklyPay;
+        map.set(key, existing);
+      });
+    });
+
+    return Array.from(map.entries())
+      .map(([label, data]) => ({ label, ...data }))
+      .sort((a, b) => b.hours - a.hours);
+  }, [metricsAssignments]);
+
+  const formatCurrency = (value) => {
+    const numberValue = Number(value || 0);
+    return `$${numberValue.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  };
+
+  const formatHoursValue = (value) => {
+    const numberValue = Number(value || 0);
+    return numberValue.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  };
 
   const handleSort = (key) => {
     setSortConfig(prev => ({
@@ -508,6 +709,84 @@ const StudentDirectory = ({ studentData, rawScheduleData, onStudentUpdate, onStu
     return `${hour}:${minutes} ${ampm}`;
   };
 
+  const exportToCSV = () => {
+    const headers = [
+      'Type',
+      'Name',
+      'Job Title',
+      'Supervisor',
+      'Email',
+      'Phone',
+      'Building(s)',
+      'Start Date',
+      'End Date',
+      'Hourly Rate',
+      'Weekly Hours',
+      'Weekly Pay',
+      'Weekly Schedule'
+    ];
+
+    const escapeCell = (value) => `"${String(value ?? '').replace(/"/g, '""')}"`;
+
+    const rows = [];
+
+    filteredAndSortedData.forEach(student => {
+      const assignments = getStudentAssignments(student);
+      if (assignments.length === 0) {
+        rows.push([
+          'Student Worker',
+          student.name || '',
+          student.jobTitle || '',
+          student.supervisor || '',
+          student.email || '',
+          student.hasNoPhone ? 'No Phone' : formatPhoneNumber(student.phone),
+          Array.isArray(student.primaryBuildings) ? student.primaryBuildings.join('; ') : (student.primaryBuilding || ''),
+          student.startDate || '',
+          student.endDate || '',
+          '',
+          '0.00',
+          '0.00',
+          formatWeeklySchedule(student.weeklySchedule)
+        ]);
+        return;
+      }
+
+      assignments.forEach(assignment => {
+        rows.push([
+          'Student Worker',
+          student.name || '',
+          assignment.jobTitle || '',
+          assignment.supervisor || '',
+          student.email || '',
+          student.hasNoPhone ? 'No Phone' : formatPhoneNumber(student.phone),
+          (assignment.buildings && assignment.buildings.length > 0)
+            ? assignment.buildings.join('; ')
+            : (Array.isArray(student.primaryBuildings) ? student.primaryBuildings.join('; ') : (student.primaryBuilding || '')),
+          student.startDate || '',
+          student.endDate || '',
+          assignment.hourlyRateNumber ? assignment.hourlyRateNumber.toFixed(2) : (assignment.hourlyRateDisplay || ''),
+          assignment.weeklyHours ? assignment.weeklyHours.toFixed(2) : '0.00',
+          assignment.weeklyPay ? assignment.weeklyPay.toFixed(2) : '0.00',
+          formatWeeklySchedule(assignment.schedule)
+        ]);
+      });
+    });
+
+    const csvContent = [headers, ...rows]
+      .map(row => row.map(escapeCell).join(','))
+      .join('\n');
+
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const link = document.createElement('a');
+    const url = URL.createObjectURL(blob);
+    link.setAttribute('href', url);
+    link.setAttribute('download', `student-worker-directory-${new Date().toISOString().split('T')[0]}.csv`);
+    link.style.visibility = 'hidden';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
   const SortableHeader = ({ label, columnKey }) => {
     const isSorted = sortConfig.key === columnKey;
     const directionIcon = isSorted ? (sortConfig.direction === 'ascending' ? '▲' : '▼') : <ArrowUpDown size={14} className="opacity-30" />;
@@ -529,7 +808,7 @@ const StudentDirectory = ({ studentData, rawScheduleData, onStudentUpdate, onStu
             <GraduationCap className="mr-2 text-baylor-gold" size={20} />
             Student Directory ({filteredAndSortedData.length})
           </h2>
-          <div className="flex items-center gap-4">
+          <div className="flex flex-wrap items-center justify-end gap-4">
             {sortConfig.key === 'name' && (
               <div className="flex items-center gap-2 text-sm">
                 <span className="text-gray-600">Sort by:</span>
@@ -553,7 +832,7 @@ const StudentDirectory = ({ studentData, rawScheduleData, onStudentUpdate, onStu
                 </div>
               </div>
             )}
-            <div className="relative">
+            <div className="relative min-w-[220px]">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
               <input
                 type="text"
@@ -561,6 +840,28 @@ const StudentDirectory = ({ studentData, rawScheduleData, onStudentUpdate, onStu
                 value={filterText}
                 onChange={(e) => setFilterText(e.target.value)}
                 className="w-full pl-10 p-2 border border-gray-300 rounded-lg focus:ring-baylor-green focus:border-baylor-green"
+              />
+            </div>
+            <div className="min-w-[200px]">
+              <MultiSelectDropdown
+                options={availableJobTitles}
+                selected={filters.jobTitles}
+                onChange={(selected) => setFilters(prev => ({
+                  ...prev,
+                  jobTitles: selected
+                }))}
+                placeholder="Filter by title"
+              />
+            </div>
+            <div className="min-w-[200px]">
+              <MultiSelectDropdown
+                options={availableBuildings}
+                selected={filters.buildings}
+                onChange={(selected) => setFilters(prev => ({
+                  ...prev,
+                  buildings: selected
+                }))}
+                placeholder="Filter by building"
               />
             </div>
             <button
@@ -608,6 +909,13 @@ const StudentDirectory = ({ studentData, rawScheduleData, onStudentUpdate, onStu
                 Include ended
               </label>
             </div>
+            <button
+              onClick={exportToCSV}
+              className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              <Download size={18} />
+              Export CSV
+            </button>
             <button
               onClick={startCreate}
               className="flex items-center gap-2 px-4 py-2 bg-baylor-green text-white rounded-lg hover:bg-baylor-green/90 transition-colors"
@@ -702,6 +1010,117 @@ const StudentDirectory = ({ studentData, rawScheduleData, onStudentUpdate, onStu
           </div>
         </div>
         )}
+
+        {/* Metrics Overview */}
+        <div className="mb-6 bg-gray-50 border border-gray-200 rounded-lg p-4">
+          <div className="flex flex-wrap items-center justify-between gap-4 mb-4">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-full bg-baylor-green/10 text-baylor-green">
+                <BarChart3 size={20} />
+              </div>
+              <div>
+                <h3 className="text-base font-semibold text-gray-900">Student Worker Hours &amp; Payroll</h3>
+                <p className="text-sm text-gray-600">Metrics update automatically based on the directory filters.</p>
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <div className="min-w-[200px]">
+                <MultiSelectDropdown
+                  options={availableJobTitles}
+                  selected={metricsFilters.jobTitles}
+                  onChange={(selected) => setMetricsFilters(prev => ({
+                    ...prev,
+                    jobTitles: selected
+                  }))}
+                  placeholder="Metrics by title"
+                />
+              </div>
+              <div className="min-w-[200px]">
+                <MultiSelectDropdown
+                  options={availableBuildings}
+                  selected={metricsFilters.buildings}
+                  onChange={(selected) => setMetricsFilters(prev => ({
+                    ...prev,
+                    buildings: selected
+                  }))}
+                  placeholder="Metrics by building"
+                />
+              </div>
+              {(metricsFilters.jobTitles.length > 0 || metricsFilters.buildings.length > 0) && (
+                <button
+                  onClick={() => setMetricsFilters({ jobTitles: [], buildings: [] })}
+                  className="px-3 py-2 text-sm text-baylor-green font-medium rounded-lg border border-baylor-green/30 hover:bg-baylor-green/10"
+                >
+                  Reset metrics filters
+                </button>
+              )}
+            </div>
+          </div>
+
+          {metricsAssignments.length === 0 ? (
+            <div className="text-sm text-gray-600 bg-white border border-dashed border-gray-300 rounded-lg p-4">
+              No assignments match the current filters. Adjust the directory or metrics filters to see totals.
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+                <div className="bg-white border border-gray-200 rounded-lg p-4">
+                  <p className="text-xs uppercase tracking-wide text-gray-500">Total Weekly Hours</p>
+                  <p className="text-2xl font-semibold text-gray-900">{formatHoursValue(metricsTotals.totalHours)} hrs</p>
+                  <p className="text-xs text-gray-500 mt-1">Across {metricsTotals.studentCount} student worker{metricsTotals.studentCount === 1 ? '' : 's'}</p>
+                </div>
+                <div className="bg-white border border-gray-200 rounded-lg p-4">
+                  <p className="text-xs uppercase tracking-wide text-gray-500">Estimated Weekly Payroll</p>
+                  <p className="text-2xl font-semibold text-gray-900">{formatCurrency(metricsTotals.totalPay)}</p>
+                  <p className="text-xs text-gray-500 mt-1">Sum of hourly rate × hours for each assignment</p>
+                </div>
+                <div className="bg-white border border-gray-200 rounded-lg p-4">
+                  <p className="text-xs uppercase tracking-wide text-gray-500">Average Hourly Rate</p>
+                  <p className="text-2xl font-semibold text-gray-900">{formatCurrency(metricsTotals.avgRate)}</p>
+                  <p className="text-xs text-gray-500 mt-1">Weighted by assignment hours</p>
+                </div>
+                <div className="bg-white border border-gray-200 rounded-lg p-4">
+                  <p className="text-xs uppercase tracking-wide text-gray-500">Assignments Count</p>
+                  <p className="text-2xl font-semibold text-gray-900">{metricsAssignments.length}</p>
+                  <p className="text-xs text-gray-500 mt-1">Active assignments in view</p>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="bg-white border border-gray-200 rounded-lg p-4">
+                  <h4 className="text-sm font-semibold text-gray-900 mb-3">Hours by Job Title</h4>
+                  {jobTitleBreakdown.length === 0 ? (
+                    <p className="text-sm text-gray-500">No job title information available.</p>
+                  ) : (
+                    <ul className="space-y-2">
+                      {jobTitleBreakdown.map((item) => (
+                        <li key={item.label} className="flex items-center justify-between text-sm">
+                          <span className="text-gray-700">{item.label}</span>
+                          <span className="text-gray-900 font-medium">{formatHoursValue(item.hours)} hrs <span className="text-gray-400">·</span> {formatCurrency(item.pay)}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+                <div className="bg-white border border-gray-200 rounded-lg p-4">
+                  <h4 className="text-sm font-semibold text-gray-900 mb-3">Hours by Building</h4>
+                  {buildingBreakdown.length === 0 ? (
+                    <p className="text-sm text-gray-500">No building assignments recorded.</p>
+                  ) : (
+                    <ul className="space-y-2">
+                      {buildingBreakdown.map((item) => (
+                        <li key={item.label} className="flex items-center justify-between text-sm">
+                          <span className="text-gray-700">{item.label}</span>
+                          <span className="text-gray-900 font-medium">{formatHoursValue(item.hours)} hrs <span className="text-gray-400">·</span> {formatCurrency(item.pay)}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
 
         {/* Create New Student Form */}
         {isCreating && (
@@ -945,6 +1364,8 @@ const StudentDirectory = ({ studentData, rawScheduleData, onStudentUpdate, onStu
                 <SortableHeader label="Email" columnKey="email" />
                 <SortableHeader label="Phone" columnKey="phone" />
                 <SortableHeader label="Weekly Schedule" columnKey="weeklySchedule" />
+                <SortableHeader label="Weekly Hours" columnKey="weeklyHours" />
+                <th className="px-4 py-3 text-left font-serif font-semibold text-baylor-green">Wage</th>
                 <SortableHeader label="Job Title" columnKey="jobTitle" />
                 <SortableHeader label="Supervisor" columnKey="supervisor" />
                 <th className="px-4 py-3 text-left font-serif font-semibold text-baylor-green">Building(s)</th>
@@ -952,8 +1373,12 @@ const StudentDirectory = ({ studentData, rawScheduleData, onStudentUpdate, onStu
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200">
-              {filteredAndSortedData.map((student) => (
-                <tr key={student.id} className="hover:bg-gray-50">
+              {filteredAndSortedData.map((student) => {
+                const assignments = getStudentAssignments(student);
+                const totalWeeklyHours = assignments.reduce((sum, assignment) => sum + assignment.weeklyHours, 0);
+                const totalWeeklyPay = assignments.reduce((sum, assignment) => sum + assignment.weeklyPay, 0);
+                return (
+                  <tr key={student.id} className="hover:bg-gray-50">
                   {editingId === student.id ? (
                     // Edit row
                     <>
@@ -1041,7 +1466,7 @@ const StudentDirectory = ({ studentData, rawScheduleData, onStudentUpdate, onStu
                           </div>
                         </div>
                       </td>
-              <td className="p-2 align-top" colSpan={3}>
+              <td className="p-2 align-top" colSpan={5}>
                 <div className="space-y-4">
                   {/* Job Management Header */}
                   <div className="flex items-center justify-between">
@@ -1312,6 +1737,37 @@ const StudentDirectory = ({ studentData, rawScheduleData, onStudentUpdate, onStu
                           <span className="text-sm text-gray-900">{formatWeeklySchedule(student.weeklySchedule) || '-'}</span>
                         </div>
                       </td>
+                      <td className="px-4 py-3 whitespace-nowrap align-top">
+                        <div className="text-sm text-gray-900 font-medium">
+                          {totalWeeklyHours > 0 ? `${formatHoursValue(totalWeeklyHours)} hrs` : '-'}
+                        </div>
+                        {assignments.length > 1 && (
+                          <div className="mt-1 space-y-1 text-xs text-gray-500">
+                            {assignments.map((assignment, idx) => (
+                              <div key={idx}>
+                                {(assignment.jobTitle || `Assignment ${idx + 1}`)}: {formatHoursValue(assignment.weeklyHours)} hrs
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap align-top">
+                        <div className="flex items-center gap-2 text-sm text-gray-900 font-medium">
+                          <DollarSign className="h-4 w-4 text-gray-400" />
+                          {assignments.length === 0 ? '-' : `${formatCurrency(totalWeeklyPay)} / wk`}
+                        </div>
+                        <div className="mt-1 space-y-1 text-xs text-gray-500">
+                          {assignments.length === 0 ? (
+                            <span>No wage data</span>
+                          ) : (
+                            assignments.map((assignment, idx) => (
+                              <div key={idx}>
+                                {(assignment.jobTitle || `Assignment ${idx + 1}`)}: {assignment.hourlyRateNumber ? `${formatCurrency(assignment.hourlyRateNumber)} / hr` : (assignment.hourlyRateDisplay || 'Rate N/A')}
+                              </div>
+                            ))
+                          )}
+                        </div>
+                      </td>
                       <td className="px-4 py-3 whitespace-nowrap">
                         <span className="text-sm text-gray-900">{student.jobTitle || '-'}</span>
                       </td>
@@ -1343,8 +1799,9 @@ const StudentDirectory = ({ studentData, rawScheduleData, onStudentUpdate, onStu
                       </td>
                     </>
                   )}
-                </tr>
-              ))}
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
## Summary
- calculate per-assignment hours and pay to drive new student worker metrics and filters
- surface weekly hours and wage details in the student directory table
- add student worker CSV export with one row per assignment including rate, hours, and pay

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc49ceb9208331af38f3538c9efe4c